### PR TITLE
libuavcan: Update submodule url and commit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/UAVCAN/dsdl.git
 [submodule "libuavcan"]
 	path = libuavcan
-	url = https://github.com/UAVCAN/libuavcan
+	url = https://github.com/UofA-SPEAR/libuavcan.git
 [submodule "libcanard"]
 	path = libcanard
 	url = https://github.com/UAVCAN/libcanard.git


### PR DESCRIPTION
Update libuavcan submodule to point to our own SPEAR fork with a patch
to support the version of ChibiOS we are currently using.